### PR TITLE
refactor: rename module path to go-rdp-screenshotter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# golangci-lint v2 config for rdp-screenshotter-go.
+# golangci-lint v2 config for go-rdp-screenshotter.
 #
 # The default linter set (errcheck, govet, ineffassign, staticcheck, unused)
 # is kept on. The tuning below documents two deliberate policy calls:
@@ -28,14 +28,14 @@ linters:
         - (*bytes.Reader).Seek
         # WriteTo targets are always *bytes.Buffer here (see sendPDU); the
         # actual socket write in sendPDU/conn.Write is checked.
-        - (*github.com/x-stp/rdp-screenshotter-go/pkg/rdp.TPKTHeader).WriteTo
-        - (*github.com/x-stp/rdp-screenshotter-go/pkg/rdp.X224ConnectionRequest).WriteTo
+        - (*github.com/x-stp/go-rdp-screenshotter/pkg/rdp.TPKTHeader).WriteTo
+        - (*github.com/x-stp/go-rdp-screenshotter/pkg/rdp.X224ConnectionRequest).WriteTo
         # Close on a conn/file we are done with, and read-deadline sets whose
         # only failure mode (closed conn) is surfaced by the following Read.
         - (net.Conn).Close
         - (net.Conn).SetReadDeadline
         - (*os.File).Close
-        - (*github.com/x-stp/rdp-screenshotter-go/pkg/rdp.Client).Close
+        - (*github.com/x-stp/go-rdp-screenshotter/pkg/rdp.Client).Close
     staticcheck:
       checks:
         - all

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -83,7 +83,7 @@ release:
     ## install
 
     ```bash
-    go install github.com/x-stp/rdp-screenshotter-go/cmd/rdp-screenshotter@{{ .Tag }}
+    go install github.com/x-stp/go-rdp-screenshotter/cmd/rdp-screenshotter@{{ .Tag }}
     ```
 
     Or download the binary for your platform from the assets below.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN        := rdp-screenshotter
-PKG        := github.com/x-stp/rdp-screenshotter-go
+PKG        := github.com/x-stp/go-rdp-screenshotter
 CMDS       := ./cmd/rdp-screenshotter ./cmd/credssp-test
 GOFLAGS    ?= -trimpath
 LDFLAGS    ?= -s -w

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ flowchart LR
 ## install
 
 ```bash
-go install github.com/x-stp/rdp-screenshotter-go/cmd/rdp-screenshotter@latest
+go install github.com/x-stp/go-rdp-screenshotter/cmd/rdp-screenshotter@latest
 ```
 
 Or build from source:
@@ -183,7 +183,7 @@ import (
     "time"
 
     "github.com/rs/zerolog"
-    "github.com/x-stp/rdp-screenshotter-go/pkg/rdp"
+    "github.com/x-stp/go-rdp-screenshotter/pkg/rdp"
 )
 
 func main() {

--- a/cmd/credssp-test/main.go
+++ b/cmd/credssp-test/main.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
-	"github.com/x-stp/rdp-screenshotter-go/pkg/rdp"
+	"github.com/x-stp/go-rdp-screenshotter/pkg/rdp"
 )
 
 func main() {

--- a/cmd/rdp-screenshotter/main.go
+++ b/cmd/rdp-screenshotter/main.go
@@ -48,7 +48,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
-	"github.com/x-stp/rdp-screenshotter-go/pkg/rdp"
+	"github.com/x-stp/go-rdp-screenshotter/pkg/rdp"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/x-stp/rdp-screenshotter-go
+module github.com/x-stp/go-rdp-screenshotter
 
 go 1.25.0
 

--- a/pkg/rdp/mcs.go
+++ b/pkg/rdp/mcs.go
@@ -13,7 +13,7 @@ import (
 	"math/big"
 	"slices"
 
-	"github.com/x-stp/rdp-screenshotter-go/pkg/rdp/per"
+	"github.com/x-stp/go-rdp-screenshotter/pkg/rdp/per"
 	"github.com/zmap/zcrypto/x509"
 )
 

--- a/pkg/rdp/read.go
+++ b/pkg/rdp/read.go
@@ -13,7 +13,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/x-stp/rdp-screenshotter-go/pkg/bitmap"
+	"github.com/x-stp/go-rdp-screenshotter/pkg/bitmap"
 )
 
 // canvasWidth / canvasHeight match the GCC client core data we advertise in


### PR DESCRIPTION
Resolves the module-path ≠ repo-name mismatch flagged in #5.

Module path was `github.com/x-stp/rdp-screenshotter-go` but the repo is `github.com/x-stp/go-rdp-screenshotter`, so the documented `go install github.com/x-stp/rdp-screenshotter-go/...` never resolved. This renames the **module path only** to match the repo — `go install github.com/x-stp/go-rdp-screenshotter/cmd/rdp-screenshotter@latest` now works.

**Binary and `cmd/rdp-screenshotter` dir are unchanged** — the tool is still invoked as `rdp-screenshotter`.

Swept `go.mod`, all imports, `.golangci.yml` (qualified exclude-funcs), `.goreleaser.yaml` + README install commands, Makefile.

Verified: `go build`/`go test -race`/`go vet` green, `golangci-lint` 0 issues, `goreleaser check` valid, gofmt clean. Unblocks the first `v*` release.