### PR TITLE
docs: pin go install to @v0.1.0 (not @latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ flowchart LR
 ## install
 
 ```bash
-go install github.com/x-stp/go-rdp-screenshotter/cmd/rdp-screenshotter@latest
+go install github.com/x-stp/go-rdp-screenshotter/cmd/rdp-screenshotter@v0.1.0
 ```
 
 Or build from source:


### PR DESCRIPTION
`@latest` installs whatever tag is newest at install time (unpinned / supply-chain risk). Pinned the README install command to the released `@v0.1.0` — reproducible, and won't silently pull a future unreviewed tag. goreleaser's footer already pins `@{{ .Tag }}`, so release notes stay version-correct automatically. Bump this line on each future release.