### PR TITLE
release: prepare v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ flowchart LR
 ## install
 
 ```bash
-go install github.com/x-stp/go-rdp-screenshotter/cmd/rdp-screenshotter@v0.1.0
+go install github.com/x-stp/go-rdp-screenshotter/cmd/rdp-screenshotter@v0.1.1
 ```
 
 Or build from source:


### PR DESCRIPTION
Bump README pin to @v0.1.1 ahead of the v0.1.1 tag (picks up #11).